### PR TITLE
Add job details view and dual description support

### DIFF
--- a/backend/src/models/Job.js
+++ b/backend/src/models/Job.js
@@ -3,7 +3,10 @@ import mongoose from 'mongoose';
 const JobSchema = new mongoose.Schema(
   {
     title: { type: String, required: true },
-    description: { type: String, default: '' }
+    shortDescription: { type: String, default: '' },
+    description: { type: String, default: '' },
+    open: { type: Boolean, default: true },
+    linkedinPostId: { type: String, default: null }
   },
   { timestamps: true }
 );

--- a/backend/src/routes/public.js
+++ b/backend/src/routes/public.js
@@ -5,14 +5,39 @@ const router = Router();
 
 // GET /api/public/jobs
 router.get('/jobs', async (_req, res) => {
-  const jobs = await Job.find().sort({ createdAt: -1 });
+  const jobs = await Job.find({ open: true }).sort({ createdAt: -1 });
   res.json(
     jobs.map(j => ({
       id: j._id,
       title: j.title,
-      description: j.description
+      shortDescription: j.shortDescription || j.description || '',
+      description: j.description || '',
+      createdAt: j.createdAt,
+      linkedinPostId: j.linkedinPostId || null
     }))
   );
+});
+
+router.get('/jobs/:id', async (req, res) => {
+  try {
+    const job = await Job.findById(req.params.id).lean();
+    if (!job || job.open === false) {
+      return res.status(404).json({ error: 'Job not found' });
+    }
+
+    res.json({
+      id: job._id,
+      title: job.title,
+      shortDescription: job.shortDescription || job.description || '',
+      description: job.description || '',
+      createdAt: job.createdAt,
+      updatedAt: job.updatedAt,
+      open: job.open !== false,
+      linkedinPostId: job.linkedinPostId || null
+    });
+  } catch (error) {
+    res.status(400).json({ error: 'Invalid job id' });
+  }
 });
 
 export default router;

--- a/backend/src/utils/linkedinClient.js
+++ b/backend/src/utils/linkedinClient.js
@@ -16,7 +16,7 @@ export async function publishJob(job) {
     action: 'PUBLISH_JOB',
     timestamp: new Date().toISOString(),
     details: {
-      description: job.description,
+      description: job.shortDescription || job.description,
       status: job.open ? 'open' : 'closed'
     }
   });

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -8,6 +8,7 @@ import ProtectedRoute from './components/auth/ProtectedRoute';
 // Pages
 import LoginPage from './pages/LoginPage';
 import JobsPage from './pages/JobsPage';
+import JobDetailsPage from './pages/JobDetailsPage';
 import AdminPage from './pages/AdminPage';
 import HRPage from './pages/HRPage';
 import ApplicantPage from './pages/ApplicantPage';
@@ -22,6 +23,7 @@ function App() {
             <Route path="/" element={<Layout />}>
               <Route index element={<Navigate to="/jobs" replace />} />
               <Route path="jobs" element={<JobsPage />} />
+              <Route path="jobs/:jobId" element={<JobDetailsPage />} />
               <Route
                 path="admin"
                 element={

--- a/frontend/src/components/common/RichTextEditor.js
+++ b/frontend/src/components/common/RichTextEditor.js
@@ -1,0 +1,71 @@
+import React, { useEffect, useRef } from 'react';
+
+const TOOLBAR_BUTTONS = [
+  { command: 'bold', label: 'Fett' },
+  { command: 'italic', label: 'Kursiv' },
+  { command: 'underline', label: 'Unterstrichen' },
+  { command: 'insertUnorderedList', label: '• Liste' },
+  { command: 'insertOrderedList', label: '1. Liste' }
+];
+
+const looksLikeHtml = (value = '') => /<\/?[a-z][\s\S]*>/i.test(value);
+
+const RichTextEditor = ({ value, onChange, placeholder }) => {
+  const editorRef = useRef(null);
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+
+    const nextValue = value || '';
+    if (looksLikeHtml(nextValue)) {
+      if (editor.innerHTML !== nextValue) {
+        editor.innerHTML = nextValue;
+      }
+    } else if (editor.innerText !== nextValue) {
+      editor.innerText = nextValue;
+    }
+  }, [value]);
+
+  const handleInput = () => {
+    const editor = editorRef.current;
+    if (!editor || typeof onChange !== 'function') return;
+    onChange(editor.innerHTML);
+  };
+
+  const handleCommand = (command) => {
+    const editor = editorRef.current;
+    if (!editor) return;
+
+    editor.focus();
+    document.execCommand(command, false, null);
+    handleInput();
+  };
+
+  return (
+    <div className="rich-text-wrapper">
+      <div className="rich-text-toolbar">
+        {TOOLBAR_BUTTONS.map((button) => (
+          <button
+            key={button.command}
+            type="button"
+            onClick={() => handleCommand(button.command)}
+            className="rich-text-button"
+          >
+            {button.label}
+          </button>
+        ))}
+      </div>
+      <div
+        ref={editorRef}
+        className="rich-text-editor"
+        contentEditable
+        suppressContentEditableWarning
+        data-placeholder={placeholder}
+        onInput={handleInput}
+      />
+    </div>
+  );
+};
+
+export default RichTextEditor;

--- a/frontend/src/components/jobs/JobCard.js
+++ b/frontend/src/components/jobs/JobCard.js
@@ -3,23 +3,13 @@ import { Calendar } from 'lucide-react';
 import { formatDistanceToNow } from 'date-fns';
 import { de } from 'date-fns/locale';
 
-const JobCard = ({ job, onApply, user }) => {
+const JobCard = ({ job, onViewDetails }) => {
   const isNew = () => {
     if (!job.createdAt) return false;
     const jobDate = new Date(job.createdAt);
     const weekAgo = new Date();
     weekAgo.setDate(weekAgo.getDate() - 7);
     return jobDate > weekAgo;
-  };
-
-  const getButtonText = () => {
-    if (!user) return 'Einloggen zum Bewerben';
-    if (user.role !== 'applicant') return 'Nur für Bewerber';
-    return 'Bewerben';
-  };
-
-  const isButtonDisabled = () => {
-    return user && user.role !== 'applicant';
   };
 
   return (
@@ -35,9 +25,11 @@ const JobCard = ({ job, onApply, user }) => {
           )}
         </div>
       </div>
-      
-      <p className="text-gray-400 mb-4 line-clamp-3">{job.description}</p>
-      
+
+      <p className="text-gray-400 mb-4 line-clamp-3">
+        {job.shortDescription || job.description}
+      </p>
+
       {job.createdAt && (
         <div className="flex items-center gap-2 text-sm text-gray-500 mb-4">
           <Calendar size={16} />
@@ -46,17 +38,12 @@ const JobCard = ({ job, onApply, user }) => {
           </span>
         </div>
       )}
-      
+
       <button
-        onClick={onApply}
-        disabled={isButtonDisabled()}
-        className={`w-full py-2 px-4 rounded transition-colors ${
-          isButtonDisabled() 
-            ? 'bg-gray-600 text-gray-400 cursor-not-allowed'
-            : 'bg-blue-600 hover:bg-blue-700 text-white'
-        }`}
+        onClick={onViewDetails}
+        className="w-full py-2 px-4 rounded transition-colors bg-blue-600 hover:bg-blue-700 text-white"
       >
-        {getButtonText()}
+        Details ansehen
       </button>
     </div>
   );

--- a/frontend/src/components/layout/Layout.js
+++ b/frontend/src/components/layout/Layout.js
@@ -64,12 +64,14 @@ const Layout = () => {
               <div className="ml-10 flex items-baseline space-x-4">
                 {getNavItems().map((item) => {
                   const Icon = item.icon;
+                  const isActive =
+                    location.pathname === item.path || location.pathname.startsWith(`${item.path}/`);
                   return (
                     <Link
                       key={item.path}
                       to={item.path}
                       className={`px-3 py-2 rounded-md text-sm font-medium flex items-center gap-2 ${
-                        location.pathname === item.path
+                        isActive
                           ? 'bg-gray-900 text-white'
                           : 'text-gray-300 hover:bg-gray-700 hover:text-white'
                       }`}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -77,3 +77,67 @@ body {
 .table td {
   @apply px-6 py-4 whitespace-nowrap text-sm text-gray-300 border-b border-gray-700;
 }
+
+.rich-text-wrapper {
+  background-color: #1f2937;
+  border: 1px solid #374151;
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.rich-text-toolbar {
+  display: flex;
+  gap: 0.25rem;
+  padding: 0.5rem;
+  background-color: #111827;
+  border-bottom: 1px solid #374151;
+}
+
+.rich-text-button {
+  font-size: 0.75rem;
+  color: #e5e7eb;
+  background: transparent;
+  border: 1px solid #4b5563;
+  border-radius: 0.375rem;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.rich-text-button:hover {
+  background-color: #1f2937;
+  color: #bfdbfe;
+}
+
+.rich-text-editor {
+  min-height: 180px;
+  padding: 0.75rem;
+  color: #f9fafb;
+  line-height: 1.6;
+  outline: none;
+  white-space: pre-wrap;
+}
+
+.rich-text-editor[contenteditable="true"]:empty:before {
+  content: attr(data-placeholder);
+  color: #6b7280;
+}
+
+.rich-text-content {
+  color: #e5e7eb;
+  line-height: 1.7;
+}
+
+.rich-text-content p {
+  margin-bottom: 1rem;
+}
+
+.rich-text-content ul,
+.rich-text-content ol {
+  margin: 1rem 0;
+  padding-left: 1.5rem;
+}
+
+.rich-text-content li {
+  margin-bottom: 0.5rem;
+}

--- a/frontend/src/pages/HRPage.js
+++ b/frontend/src/pages/HRPage.js
@@ -2,6 +2,8 @@ import React, { useState, useEffect } from 'react';
 import { Plus, Edit2, Trash2, Calendar, Users, MapPin, Clock, ChevronDown, ChevronUp, AlertCircle, LayoutDashboard } from 'lucide-react';
 import api from '../services/api';
 import toast from 'react-hot-toast';
+import RichTextEditor from '../components/common/RichTextEditor';
+import formatRichText from '../utils/richText';
 
 const meetingStatusMeta = {
   proposed: { color: 'bg-blue-600', label: 'Termine vorgeschlagen' },
@@ -594,7 +596,17 @@ const HRPage = () => {
           <div className="flex justify-between items-start mb-4">
             <div>
               <h2 className="text-xl font-semibold text-white mb-2">{selectedJob.title}</h2>
-              <p className="text-gray-400 mb-2">{selectedJob.description}</p>
+              <p className="text-gray-400 mb-2">
+                {selectedJob.shortDescription || 'Keine Kurzbeschreibung hinterlegt'}
+              </p>
+              {selectedJob.description ? (
+                <div
+                  className="rich-text-content mb-3"
+                  dangerouslySetInnerHTML={{ __html: formatRichText(selectedJob.description || '') }}
+                />
+              ) : (
+                <p className="text-gray-500 italic mb-3">Noch keine ausführliche Beschreibung hinterlegt.</p>
+              )}
               <div className="flex gap-2 items-center">
                 <span className={`text-xs px-2 py-1 rounded ${selectedJob.open ? 'bg-green-600' : 'bg-red-600'} text-white`}>
                   {selectedJob.open ? 'Offen' : 'Geschlossen'}
@@ -897,6 +909,7 @@ const MeetingCard = ({ meeting }) => {
 const JobModal = ({ job, onClose, onSave }) => {
   const [formData, setFormData] = useState({
     title: job?.title || '',
+    shortDescription: job?.shortDescription || '',
     description: job?.description || '',
     open: job?.open ?? true,
   });
@@ -925,13 +938,29 @@ const JobModal = ({ job, onClose, onSave }) => {
           </div>
 
           <div>
-            <label className="form-label">Beschreibung</label>
+            <label className="form-label">Kurze Beschreibung *</label>
             <textarea
-              value={formData.description}
-              onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+              value={formData.shortDescription}
+              onChange={(e) => setFormData({ ...formData, shortDescription: e.target.value })}
               className="form-input"
-              rows={4}
+              rows={3}
+              required
             />
+            <p className="text-xs text-gray-400 mt-1">
+              Diese Version wird auf der öffentlichen Übersicht angezeigt.
+            </p>
+          </div>
+
+          <div>
+            <label className="form-label">Ausführliche Beschreibung</label>
+            <RichTextEditor
+              value={formData.description}
+              onChange={(value) => setFormData({ ...formData, description: value })}
+              placeholder="Beschreibe die Stelle mit allen Details"
+            />
+            <p className="text-xs text-gray-400 mt-2">
+              Formatierungen und Absätze werden in den Jobdetails angezeigt.
+            </p>
           </div>
 
           <div>

--- a/frontend/src/pages/JobDetailsPage.js
+++ b/frontend/src/pages/JobDetailsPage.js
@@ -1,0 +1,180 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { ArrowLeft, Calendar } from 'lucide-react';
+import { formatDistanceToNow } from 'date-fns';
+import { de } from 'date-fns/locale';
+import toast from 'react-hot-toast';
+import api from '../services/api';
+import { useAuth } from '../context/AuthContext';
+import ApplyModal from '../components/jobs/ApplyModal';
+import LoginModal from '../components/auth/LoginModal';
+import formatRichText from '../utils/richText';
+
+const JobDetailsPage = () => {
+  const { jobId } = useParams();
+  const navigate = useNavigate();
+  const { user } = useAuth();
+
+  const [job, setJob] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [showApplyModal, setShowApplyModal] = useState(false);
+  const [showLoginModal, setShowLoginModal] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadJob = async () => {
+      setLoading(true);
+      try {
+        const response = await api.get(`/public/jobs/${jobId}`);
+        if (isMounted) {
+          setJob(response.data);
+        }
+      } catch (error) {
+        if (error.response?.status === 404) {
+          toast.error('Job nicht gefunden');
+          navigate('/jobs');
+        } else if (error.response?.status === 400) {
+          toast.error('Ungültige Job-ID');
+          navigate('/jobs');
+        } else {
+          console.error('Error fetching job details:', error);
+          toast.error('Jobdetails konnten nicht geladen werden');
+        }
+      } finally {
+        if (isMounted) {
+          setLoading(false);
+        }
+      }
+    };
+
+    loadJob();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [jobId, navigate]);
+
+  const handleApplyClick = () => {
+    if (!job) return;
+
+    if (!job.open) {
+      toast.error('Bewerbungen für diese Stelle sind geschlossen');
+      return;
+    }
+
+    if (!user) {
+      setShowLoginModal(true);
+      return;
+    }
+
+    if (user.role !== 'applicant') {
+      toast.error('Nur Bewerber können sich bewerben');
+      return;
+    }
+
+    setShowApplyModal(true);
+  };
+
+  const handleLoginSuccess = () => {
+    setShowLoginModal(false);
+    setShowApplyModal(true);
+  };
+
+  const formattedDescription = useMemo(() => formatRichText(job?.description || ''), [job?.description]);
+  const applyButtonLabel = useMemo(() => {
+    if (!job?.open) {
+      return 'Bewerbungen geschlossen';
+    }
+    return user ? 'Jetzt bewerben' : 'Zum Bewerben einloggen';
+  }, [job?.open, user]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-gray-900 flex items-center justify-center">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto mb-4"></div>
+          <p className="text-gray-400">Jobdetails werden geladen...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!job) {
+    return null;
+  }
+
+  return (
+    <div className="px-4 py-6">
+      <div className="mb-6">
+        <button
+          onClick={() => navigate('/jobs')}
+          className="flex items-center gap-2 text-gray-300 hover:text-white"
+        >
+          <ArrowLeft size={18} />
+          Zurück zu den Jobs
+        </button>
+      </div>
+
+      <div className="card max-w-4xl mx-auto">
+        <div className="flex flex-col md:flex-row md:items-start md:justify-between gap-4 mb-4">
+          <div>
+            <h1 className="text-3xl font-bold text-white mb-2">{job.title}</h1>
+            <p className="text-gray-300">
+              {job.shortDescription || 'Keine Kurzbeschreibung verfügbar.'}
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className={`text-xs px-2 py-1 rounded ${job.open ? 'bg-green-600' : 'bg-red-600'} text-white`}>
+              {job.open ? 'Offen' : 'Geschlossen'}
+            </span>
+            {job.linkedinPostId && (
+              <span className="text-xs px-2 py-1 rounded bg-blue-500 text-white">LinkedIn</span>
+            )}
+          </div>
+        </div>
+
+        {job.createdAt && (
+          <div className="flex items-center gap-2 text-sm text-gray-500 mb-6">
+            <Calendar size={16} />
+            <span>Vor {formatDistanceToNow(new Date(job.createdAt), { locale: de })}</span>
+          </div>
+        )}
+
+        {formattedDescription ? (
+          <div className="rich-text-content mb-6" dangerouslySetInnerHTML={{ __html: formattedDescription }} />
+        ) : (
+          <p className="text-gray-400 mb-6">
+            Für diese Stelle liegt noch keine ausführliche Beschreibung vor.
+          </p>
+        )}
+
+        <div className="flex flex-col sm:flex-row gap-3">
+          <button
+            onClick={handleApplyClick}
+            className="flex-1 btn-primary"
+            disabled={!job.open}
+          >
+            {applyButtonLabel}
+          </button>
+        </div>
+      </div>
+
+      <LoginModal
+        isOpen={showLoginModal}
+        onClose={() => setShowLoginModal(false)}
+        onSuccess={handleLoginSuccess}
+      />
+
+      {showApplyModal && (
+        <ApplyModal
+          job={job}
+          onClose={() => setShowApplyModal(false)}
+          onSuccess={() => setShowApplyModal(false)}
+        />
+      )}
+    </div>
+  );
+};
+
+export default JobDetailsPage;

--- a/frontend/src/pages/JobsPage.js
+++ b/frontend/src/pages/JobsPage.js
@@ -1,18 +1,12 @@
 import React, { useState, useEffect } from 'react';
-import { useAuth } from '../context/AuthContext';
+import { useNavigate } from 'react-router-dom';
 import api from '../services/api';
-import toast from 'react-hot-toast'; // <- DIESER IMPORT FEHLTE
 import JobCard from '../components/jobs/JobCard';
-import ApplyModal from '../components/jobs/ApplyModal';
-import LoginModal from '../components/auth/LoginModal';
 
 const JobsPage = () => {
-  const { user } = useAuth();
+  const navigate = useNavigate();
   const [jobs, setJobs] = useState([]);
   const [loading, setLoading] = useState(true);
-  const [selectedJob, setSelectedJob] = useState(null);
-  const [showApplyModal, setShowApplyModal] = useState(false);
-  const [showLoginModal, setShowLoginModal] = useState(false);
 
   useEffect(() => {
     fetchJobs();
@@ -26,29 +20,6 @@ const JobsPage = () => {
       console.error('Error fetching jobs:', error);
     } finally {
       setLoading(false);
-    }
-  };
-
-  const handleApply = (job) => {
-    if (!user) {
-      setSelectedJob(job);
-      setShowLoginModal(true);
-      return;
-    }
-    
-    if (user.role !== 'applicant') {
-      toast.error('Nur Bewerber können sich bewerben');
-      return;
-    }
-    
-    setSelectedJob(job);
-    setShowApplyModal(true);
-  };
-
-  const handleLoginSuccess = () => {
-    setShowLoginModal(false);
-    if (selectedJob) {
-      setShowApplyModal(true);
     }
   };
 
@@ -79,37 +50,13 @@ const JobsPage = () => {
       ) : (
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
           {jobs.map((job) => (
-            <JobCard 
-              key={job.id} 
-              job={job} 
-              onApply={() => handleApply(job)}
-              user={user}
+            <JobCard
+              key={job.id}
+              job={job}
+              onViewDetails={() => navigate(`/jobs/${job.id}`)}
             />
           ))}
         </div>
-      )}
-
-      <LoginModal
-        isOpen={showLoginModal}
-        onClose={() => {
-          setShowLoginModal(false);
-          setSelectedJob(null);
-        }}
-        onSuccess={handleLoginSuccess}
-      />
-
-      {showApplyModal && selectedJob && (
-        <ApplyModal
-          job={selectedJob}
-          onClose={() => {
-            setShowApplyModal(false);
-            setSelectedJob(null);
-          }}
-          onSuccess={() => {
-            setShowApplyModal(false);
-            setSelectedJob(null);
-          }}
-        />
       )}
     </div>
   );

--- a/frontend/src/utils/richText.js
+++ b/frontend/src/utils/richText.js
@@ -1,0 +1,56 @@
+const HTML_TAG_REGEX = /<\/?[a-z][\s\S]*>/i;
+const ALLOWED_TAGS = new Set(['P', 'BR', 'STRONG', 'EM', 'UL', 'OL', 'LI', 'U']);
+
+const escapeHtml = (value = '') =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#039;');
+
+const sanitizeHtmlString = (value = '') => {
+  if (typeof window === 'undefined' || typeof window.DOMParser === 'undefined') {
+    return escapeHtml(value);
+  }
+
+  const parser = new window.DOMParser();
+  const doc = parser.parseFromString(value, 'text/html');
+  const { body } = doc;
+
+  const sanitizeNode = (node) => {
+    const children = Array.from(node.childNodes);
+
+    children.forEach((child) => {
+      if (child.nodeType === 1) {
+        if (!ALLOWED_TAGS.has(child.tagName)) {
+          const fragment = doc.createDocumentFragment();
+          Array.from(child.childNodes).forEach((grandChild) => {
+            fragment.appendChild(grandChild);
+          });
+          child.replaceWith(fragment);
+        } else {
+          Array.from(child.attributes).forEach((attr) => child.removeAttribute(attr.name));
+          sanitizeNode(child);
+        }
+      } else if (child.nodeType === 8) {
+        child.remove();
+      }
+    });
+  };
+
+  sanitizeNode(body);
+  return body.innerHTML;
+};
+
+export const formatRichText = (value = '') => {
+  if (!value) return '';
+
+  if (HTML_TAG_REGEX.test(value)) {
+    return sanitizeHtmlString(value);
+  }
+
+  return escapeHtml(value).replace(/\n/g, '<br />');
+};
+
+export default formatRichText;

--- a/mobile-app/src/screens/JobsScreen.js
+++ b/mobile-app/src/screens/JobsScreen.js
@@ -23,7 +23,9 @@ const JobsScreen = () => {
   const renderJob = ({item}) => (
     <View style={styles.jobCard}>
       <Text style={styles.jobTitle}>{item.title}</Text>
-      <Text style={styles.jobDescription}>{item.description}</Text>
+      <Text style={styles.jobDescription}>
+        {(item.shortDescription || item.description || '').replace(/<[^>]+>/g, '').trim()}
+      </Text>
       <TouchableOpacity style={styles.applyButton}>
         <Text style={styles.applyButtonText}>
           {user ? 'Bewerben' : 'Einloggen zum Bewerben'}


### PR DESCRIPTION
## Summary
- add a shortDescription field to job data, expose a public job detail endpoint, and ensure admin APIs return both text variants
- create a dedicated job detail page on the frontend that renders formatted descriptions and moves the apply/login flow behind a details button
- enhance the HR job management modal with separate short/long descriptions and a lightweight rich text editor while updating styling/helpers

## Testing
- `npm test`
- `npm test -- --watchAll=false` *(fails: CRA/Jest cannot parse axios ESM import without additional transformers)*

------
https://chatgpt.com/codex/tasks/task_e_68c8960314848329b92258b962d08eca